### PR TITLE
ci: rationalise to a lean push gate; heavy suites manual + monthly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,113 +2,83 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
+# Lean gate: lint + type-check + unit/component tests + build, on a single
+# Node and Python. This is the only suite that runs on every push/PR.
+#
+# The heavy suites (perf, memory, e2e, playwright, lighthouse, security-scan)
+# live in comprehensive-testing.yml and run on-demand (workflow_dispatch) or
+# monthly — not on every push. Run them locally during development:
+#   pnpm test            # frontend unit/component
+#   pnpm run test:e2e    # Playwright E2E
+#   cd backend && pytest # backend
 jobs:
-  test-frontend:
+  frontend:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x]
-
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
 
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-    - name: Run linter
-      run: pnpm run lint
-      continue-on-error: true
+      - name: Lint
+        run: pnpm run lint
+        continue-on-error: true  # informational; doesn't gate the merge
 
-    - name: Run type check
-      run: npx tsc --noEmit
+      - name: Type check
+        run: pnpm run type-check
 
-    - name: Run tests
-      run: pnpm test
+      - name: Unit & component tests
+        run: pnpm test
 
-    - name: Build application
-      run: pnpm run build
+      - name: Build
+        run: pnpm run build
 
-  test-backend:
+  backend:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11']
-
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-    - name: Cache pip packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements-dev.txt', 'backend/requirements-minimal.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-    - name: Install dependencies
-      run: |
-        cd backend
-        python -m pip install --upgrade pip
-        pip install -r requirements-minimal.txt
-        pip install slowapi "python-jose[cryptography]" "passlib[bcrypt]" bleach validators redis celery python-multipart httpx
-        pip install pytest pytest-cov flake8
+      - name: Install dependencies
+        # requirements-dev.txt = minimal runtime deps + pytest + httpx (the
+        # FastAPI TestClient backend). flake8 is dev-only, installed alongside.
+        run: |
+          cd backend
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt flake8
 
-    - name: Lint with flake8
-      run: |
-        cd backend
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Lint (flake8 — fail only on real errors)
+        run: |
+          cd backend
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    - name: Test with pytest
-      run: |
-        cd backend
-        pytest --cov=./ --cov-report=xml
-
-  lighthouse:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-
-    - name: Use Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18.x'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-
-    - name: Build application
-      run: pnpm run build
-
-    - name: Run Lighthouse CI
-      uses: treosh/lighthouse-ci-action@v10
-      with:
-        configPath: './lighthouserc.json'
-        uploadArtifacts: true
-        temporaryPublicStorage: true
-      continue-on-error: true
+      - name: Test with pytest
+        run: |
+          cd backend
+          pytest -q

--- a/.github/workflows/comprehensive-testing.yml
+++ b/.github/workflows/comprehensive-testing.yml
@@ -1,13 +1,12 @@
 name: Comprehensive Testing Pipeline
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  # Heavy suites — NOT run on every push/PR. Trigger on-demand from the Actions
+  # tab (Run workflow) or via the monthly schedule. Run them locally otherwise.
+  workflow_dispatch:
   schedule:
-    # Run comprehensive tests daily at 2 AM UTC
-    - cron: '0 2 * * *'
+    # Monthly: 1st of the month at 02:00 UTC
+    - cron: '0 2 1 * *'
 
 env:
   NODE_VERSION: '18'
@@ -286,10 +285,14 @@ jobs:
       run: pip install -r backend/requirements-minimal.txt
 
     - name: Install Playwright browsers
-      run: pnpm exec playwright install --with-deps
+      run: pnpm exec playwright install --with-deps chromium
 
     - name: Run Playwright E2E tests
-      run: pnpm run test:e2e
+      # Chromium-only with a single retry: the full 3-browser × retries:2 matrix
+      # (384 runs, 1 worker) blew past the 30-min timeout and was always
+      # cancelled. Chromium gives the signal in a fraction of the time; run the
+      # other browsers locally (`pnpm run test:e2e`) when needed.
+      run: pnpm exec playwright test --project=chromium --retries=1
       env:
         ENVIRONMENT: test
         API_KEY: test-api-key-secure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  # Allow manual deployment
+  # Allow manual deployment. (Dropped the per-PR build — the static export is
+  # verified on merge to main; run `pnpm run build:static` locally to check.)
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ backend/cache/
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # Build outputs


### PR DESCRIPTION
## What & why

CI was running a huge redundant matrix on **every push/PR** — frontend tests twice, backend across 3 Python versions, builds 4+ times, plus perf/memory/e2e/playwright/lighthouse. Per request: keep a fast high-signal gate on push, move the heavy stuff off the hot path (run locally, on-demand, or monthly).

## On every push/PR now (`ci.yml`)
A single lean gate on **Node 20 / Python 3.11**:
- ✓ lint (informational) · type-check · frontend unit/component (jest) · build
- ✓ backend flake8 + pytest

Dropped: the duplicate frontend suite, the 18.x/20.x + 3.9/3.10/3.11 matrices, per-PR lighthouse, per-PR static build.

## Moved to manual + monthly (`comprehensive-testing.yml`)
perf-benchmarks, memory-leak, e2e-integration, playwright, security-scan, etc. now trigger via **workflow_dispatch** + a **monthly** cron (1st @ 02:00 UTC) — not on push/PR.

Playwright was chronically **cancelled** (384 tests × 3 browsers × retries:2, 1 worker → always hit the 30-min timeout; red on every run for weeks incl. main). Trimmed to **chromium-only, retries:1** so the monthly/manual run actually completes. Other browsers run locally via `pnpm run test:e2e`.

## deploy.yml
Dropped the per-PR build; static export is verified on merge to main (+ manual dispatch).

## Housekeeping
- gitignore `backend/coverage.xml` (pytest-cov artifact).

## Verification
- Backend suite **52 passed** + flake8 clean under the exact lean install (`requirements-dev.txt` + flake8 — no jose/passlib/validators/redis/celery needed).
- Frontend gate commands already green on Node 20 (from #109's `test-frontend`).

> Note: CodeQL (default setup) and Socket Security are GitHub app integrations configured in repo settings, not workflow files — unaffected by this PR.