### PR TITLE
ci(dependabot): pin numpy/scipy to audiocraft-compatible graph

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,13 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    ignore:
+      # numpy/scipy are pinned in requirements.txt to the versions audiocraft==1.3.0
+      # is known to work with — audiocraft 1.3.0 caps numpy<2.0, and scipy 1.16+
+      # requires numpy>=1.25.2. Bumping either breaks the AI/torch dependency graph
+      # (see the header comment in backend/requirements.txt). The minimal/test
+      # backend (requirements-minimal.txt) intentionally allows newer numpy/scipy
+      # via >= ranges since it has no torch/audiocraft. Bumping these is a manual,
+      # audiocraft-coordinated decision, not an automated one.
+      - dependency-name: "numpy"
+      - dependency-name: "scipy"


### PR DESCRIPTION
Stops dependabot from reopening numpy 2.x / scipy 1.16 PRs that break the AI stack.

**Why:** `backend/requirements.txt` pins `numpy==1.24.3 / scipy==1.11.4` because **audiocraft==1.3.0 caps numpy<2.0**, and scipy 1.16+ requires numpy>=1.25.2 — so both #97 and #96 would break `pip install -r requirements.txt` (torch/audiocraft graph). This is documented in that file's header; the pins are deliberate.

`requirements-minimal.txt` (test/lean backend, no torch) keeps its `numpy>=1.26 / scipy>=1.12` ranges — unaffected.

Adds `ignore` rules for numpy + scipy in the pip ecosystem. Closes out the Tier-2 numpy/scipy item by **rejecting** the bumps with rationale rather than merging them.

Refs #111. Supersedes #97, #96 (closing those).